### PR TITLE
Avoid the exception handler to throw exception

### DIFF
--- a/resilient-circuits/resilient_circuits/actions_component.py
+++ b/resilient-circuits/resilient_circuits/actions_component.py
@@ -700,7 +700,7 @@ class Actions(ResilientComponent):
                 message = u"Processing failed"
             if traceback and isinstance(traceback, list):
                 message = message + "\n" + ("".join(traceback))
-            LOG.exception(u"%s (%s): %s", repr(fevent), repr(etype), message)
+            LOG.error(u"%s (%s): %s", repr(fevent), repr(etype), message)
             # Try find the underlying Action or Function message
             if fevent and fevent.args and not isinstance(fevent, ActionMessageBase):
                 for arg in fevent.args:
@@ -734,6 +734,8 @@ class Actions(ResilientComponent):
                     LOG.debug("Test Action: No ack done.")
         except Exception as err:
             LOG.error("Exception handler threw exception! Response to action module may not have sent.")
+            LOG.error(err)
+            LOG.error("Original exception traceback.")
             LOG.error(traceback)
 
     @handler("Ack_failure")


### PR DESCRIPTION
The handler is calling LOG.exception, which generates a new exception, thus preventing the handler from completing successfully and properly processing the event.
I modified the except block in the handler to print the error message associated with the exception generated in the handler and caught. This should facilitate the troubleshooting in case the handler fails.