### PR TITLE
support output base option for codegen command

### DIFF
--- a/resilient-circuits/resilient_circuits/bin/resilient_circuits_cmd.py
+++ b/resilient-circuits/resilient_circuits/bin/resilient_circuits_cmd.py
@@ -256,7 +256,7 @@ def generate_code(args):
 
     if args.package:
         # codegen an installable package
-        output_base = os.path.join(os.curdir, args.package)
+        output_base = args.output_base or os.path.join(os.curdir, args.package)
         codegen_package(client, args.exportfile, args.package,
                         args.messagedestination, args.function, args.workflow, args.rule,
                         args.field, args.datatable, args.task, args.script,
@@ -335,6 +335,10 @@ def main():
     # Options for 'codegen'
     codegen_parser.add_argument("-p", "--package",
                                 help="Name of the package to generate")
+    codegen_parser.add_argument("--output-base",
+                                help="Name of the directory to write all codegen output to."
+                                     "(default's to the package name in the current folder)."
+                                )
     codegen_parser.add_argument("-o", "--output",
                                 help="Output file name")
     codegen_parser.add_argument("-f", "--function",


### PR DESCRIPTION
__TL;DR__: Add support for `codegen` command to output to the current folder, or any other custom folder. No default functionality was changed.

Before this change was applied, the output of the codegen command was always preset to './<package_name>'. That way developers are forced to execute the `resilient-circuits` commands from outside the root folder of their project. I believe that this is not the best practice...

To allow the execution of the `codegen` command from the level of the `setup.py` file, I added the "--output-base" option. In that case, if the user execute the `codegen` with `--output-base .`, all files will `codegen` files will be created within the current folder, and not under the `<package-name>` subfolder in the current folder.