### PR TITLE
Added flexibility to how Circuits is started

### DIFF
--- a/resilient-circuits/resilient_circuits/component_loader.py
+++ b/resilient-circuits/resilient_circuits/component_loader.py
@@ -48,7 +48,7 @@ def safe_but_noisy_import(name):
 class ComponentLoader(Loader):
     """A component to automatically load from the componentsdir directory"""
 
-    def __init__(self, opts):
+    def __init__(self, opts, components_to_register=None):
         """Initialize the loader"""
         self.opts = opts
         # Path where components should be found
@@ -60,8 +60,13 @@ class ComponentLoader(Loader):
         self.pending_components = []
         self.finished = False
 
-        # Load all installed components
-        installed_components = self.discover_installed_components()
+        # Load all installed components or the list passed to the
+        # constructor, giving preference to the later.
+        if components_to_register:
+            installed_components = components_to_register
+        else:
+            installed_components = self.discover_installed_components()
+
         if installed_components:
             self._register_components(installed_components)
 

--- a/resilient/resilient/co3argparse.py
+++ b/resilient/resilient/co3argparse.py
@@ -89,22 +89,27 @@ class ArgumentParser(argparse.ArgumentParser):
 
         # Read configuration options.
         if config_file:
-            config_path = ensure_unicode(config_file)
-            config_path = os.path.expanduser(config_path)
-            if os.path.exists(config_path):
-                try:
-                    self.config = configparser.ConfigParser(interpolation=None)
-                    with open(config_path, 'r', encoding='utf-8') as f:
-                        first_byte = f.read(1)
-                        if first_byte != u'\ufeff':
-                            # Not a BOM, no need to skip first byte
-                            f.seek(0)
-                        self.config.read_file(f)
-                except Exception as exc:
-                    logger.warn(u"Couldn't read config file '%s': %s", config_path, exc)
-                    self.config = None
+            # If a ConfigParser instance is passed to the constructor,
+            # it gets assigned directly to self.config
+            if isinstance(config_file, configparser.ConfigParser):
+                self.config = config_file
             else:
-                logger.warn(u"Couldn't read config file '%s'", config_file)
+                config_path = ensure_unicode(config_file)
+                config_path = os.path.expanduser(config_path)
+                if os.path.exists(config_path):
+                    try:
+                        self.config = configparser.ConfigParser(interpolation=None)
+                        with open(config_path, 'r', encoding='utf-8') as f:
+                            first_byte = f.read(1)
+                            if first_byte != u'\ufeff':
+                                # Not a BOM, no need to skip first byte
+                                f.seek(0)
+                            self.config.read_file(f)
+                    except Exception as exc:
+                        logger.warn(u"Couldn't read config file '%s': %s", config_path, exc)
+                        self.config = None
+                else:
+                    logger.warn(u"Couldn't read config file '%s'", config_file)
 
         default_email = self.getopt("resilient", "email")
         default_password = self.getopt("resilient", "password")


### PR DESCRIPTION
We are using an encrypted keyring which demands to manually insert the password when Circuits is launched from the command line. However, this does not work with the systemd unit recommended in the installation guide, as it relies on stdin to be available. 

Moreover, it’s not possible to provide the password programatically, which would allow to get the password from an arbitrary "safe" location (for instance, this could be obtained from Azure KeyVault, AWS HSM, etc.)

Now it’s possible to create a App object like this:

```
application = App(config_file=parser)
application.run()
```
Where `parser` is a ConfigParser object.

ComponentLoader has been also updated to get an optional list of components to load. This allows to create an App instance per group of components/Python package, improving performance:

```
application = App(config_file=parser, auto_load_components=False)
application.component_loader = ComponentLoader(application.opts, components_to_register=components)
application.component_loader.register(application)
application.run()
```