### PR TITLE
support for api_key in pytest-resilient-circuits

### DIFF
--- a/pytest-resilient-circuits/pytest_resilient_circuits/plugin.py
+++ b/pytest-resilient-circuits/pytest_resilient_circuits/plugin.py
@@ -9,6 +9,8 @@ from pytest_resilient_circuits.resilient_circuits_fixtures import *
 _help_email = "Resilient user email"
 _help_host = "Resilient host"
 _help_password = "Resilient password"
+_help_api_key_id = "Resilient API key ID"
+_help_api_key_secret = "Resilient API key secret"
 _help_org = "Resilient org"
 _help_app_config = "Resilient app.config file"
 
@@ -29,6 +31,18 @@ def pytest_addoption(parser):
 
     parser.addoption("--resilient_password",
                      help=_help_password,
+                     action="store",
+                     default="",
+                     required=False)
+
+    parser.addoption("--resilient_api_key_id",
+                     help=_help_api_key_id,
+                     action="store",
+                     default="",
+                     required=False)
+
+    parser.addoption("--resilient_api_key_secret",
+                     help=_help_api_key_secret,
                      action="store",
                      default="",
                      required=False)

--- a/pytest-resilient-circuits/pytest_resilient_circuits/resilient_circuits_fixtures.py
+++ b/pytest-resilient-circuits/pytest_resilient_circuits/resilient_circuits_fixtures.py
@@ -53,10 +53,10 @@ class ConfiguredAppliance:
 
         # Connect to Resilient
         self.client = resilient.SimpleClient(org_name=org, base_url=url, verify=False)
-        if user is not None:
-            self.client.connect(user, password)
-        else:
+        if api_key_id is not None:
             self.client.set_api_key(api_key_id=api_key_id, api_key_secret=api_key_secret)
+        else:
+            self.client.connect(user, password)
 
         # Retrieve constants from appliance
         constants = self._get_constants()["actions_framework"]

--- a/pytest-resilient-circuits/pytest_resilient_circuits/resilient_circuits_fixtures.py
+++ b/pytest-resilient-circuits/pytest_resilient_circuits/resilient_circuits_fixtures.py
@@ -46,11 +46,17 @@ class ConfiguredAppliance:
         org = os.environ.get("TEST_RESILIENT_ORG", request.config.option.resilient_org)
         user = os.environ.get("TEST_RESILIENT_USER", request.config.option.resilient_email)
         password = os.environ.get("TEST_RESILIENT_PASSWORD", request.config.option.resilient_password)
-        assert all((host, org, user, password))
+        api_key_id = os.environ.get("TEST_RESILIENT_API_KEY_ID", request.config.option.resilient_api_key_id)
+        api_key_secret = os.environ.get("TEST_RESILIENT_API_KEY_SECRET", request.config.option.resilient_api_key_secret)
+
+        assert all((host, org)) and (all(user, password) or all(api_key_id, api_key_secret))
 
         # Connect to Resilient
         self.client = resilient.SimpleClient(org_name=org, base_url=url, verify=False)
-        session = self.client.connect(user, password)
+        if user is not None:
+            self.client.connect(user, password)
+        else:
+            self.client.set_api_key(api_key_id=api_key_id, api_key_secret=api_key_secret)
 
         # Retrieve constants from appliance
         constants = self._get_constants()["actions_framework"]
@@ -395,6 +401,20 @@ port = 443
         password = os.environ.get("TEST_RESILIENT_PASSWORD", request.config.option.resilient_password)
         if password:
             config_parser.set(RESILIENT, "password", password)
+
+        api_key_id = os.environ.get("TEST_RESILIENT_API_KEY_ID")
+        if api_key_id:
+            print("TEST api_key_id={} (from environment)".format(api_key_id))
+        else:
+            api_key_id = request.config.option.resilient_api_key_id
+            print("TEST api_key_id={} (from configuration data)".format(api_key_id))
+
+        if api_key_id:
+            config_parser.set(RESILIENT, "api_key_id", api_key_id)
+
+        api_key_secret = os.environ.get("TEST_RESILIENT_API_KEY_SECRET", request.config.option.resilient_api_key_secret)
+        if api_key_secret:
+            config_parser.set(RESILIENT, "api_key_secret", api_key_secret)
 
         # common values
         config_parser.set(RESILIENT, "no_prompt_password", "True")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds support for api_key to the pytest_resilient_circuits package.

## Motivation and Context

When a resilient client is obtained through the get_client call
https://github.com/ibmresilient/resilient-python-api/blob/e9bbe7ac8daf6794ab64a6cdbb971785a11c7102/resilient/resilient/co3.py#L100
there is support for both api_keys
https://github.com/ibmresilient/resilient-python-api/blob/e9bbe7ac8daf6794ab64a6cdbb971785a11c7102/resilient/resilient/co3.py#L162
and a session based connection with user/pw
https://github.com/ibmresilient/resilient-python-api/blob/e9bbe7ac8daf6794ab64a6cdbb971785a11c7102/resilient/resilient/co3.py#L166

The pytest-resilient-circuits package in one area does not use get_client though and only directly creates its client through the client constructor, and in another area it constructs the arguments to pass on to the main API but does not pass on the api key, so the pytest framework code previously only supported user/password and the connect method for authentication.

## How Has This Been Tested?
Manually tested with api_key and api_key_secret set in environment and the connection works
Manually tested with user and password set in environment with no api_key and the connection still attempts the connect as it did before if api key and secret are not set.

No test case was added since it doesn't look like there are existing test cases for any of the config and environment variables used here.

pylint and pycodestyle showed some warnings, but "fixing" these would have made the new code inconsistent with existing code, or would have required more extensive changes to existing code.

## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/IBMResilient/resilient-community-apps/blob/master/CONTRIBUTING.md)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run pep8 and pylint. I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jonathan Brunn <jbrunn@us.ibm.com>
