### PR TITLE
fixed update_token infinite recursion bug

### DIFF
--- a/resilient-lib/resilient_lib/components/oauth2_client_credentials_session.py
+++ b/resilient-lib/resilient_lib/components/oauth2_client_credentials_session.py
@@ -137,7 +137,8 @@ class OAuth2ClientCredentialsSession(requests.Session):
         Returns :class:`Response <Response>` object.
         """
 
-        if self.expiration_time is not None:
+        # don't check expiration if attempting to refresh authorization - would cause infinite recursion loop
+        if self.expiration_time is not None and url != self.authorization_url:
             if self.expiration_time < time.time():
                 self.update_token()
 


### PR DESCRIPTION
Signed-off-by: Liam Mahoney <lmahoney@oshkoshcorp.com>

Fixed infinite recursion bug in the `resilient-lib.OAuth2ClientCredentialsSession.update_token` method.

## Description

Added the logic to make sure that the request isn't to refresh the authorization token before checking whether that token is expired. 

## Motivation and Context

#17 

## How Has This Been Tested?

Verified that I can refresh an expired bearer token with Microsoft Security Graph after this change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/IBMResilient/resilient-community-apps/blob/master/CONTRIBUTING.md)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [ ] I have run pep8 and pylint. I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Liam Mahoney <lmahoney@oshkoshcorp.com>