### PR TITLE
Reword warning message in app selftest

### DIFF
--- a/resilient-circuits/resilient_circuits/cmds/selftest.py
+++ b/resilient-circuits/resilient_circuits/cmds/selftest.py
@@ -70,7 +70,7 @@ def check_soar_rest_connection(cmd_line_args, app_configs):
     cafile = app_configs.get("cafile") if app_configs.get("cafile") else ""
 
     if not os.path.isfile(cafile):
-        LOG.warning("- WARNING: No certificate file specified, connection will not be secure")
+        LOG.warning("- WARNING: No certificate file specified. Only allows the connections that trusted by operating system.")
 
     LOG.info("- Checking if we can authenticate a REST connection with '{0}' to '{1}'".format(user, host))
 


### PR DESCRIPTION
Reword warning message in app selftest.

## Description

Reword the selftest warning message while verifying connection using operating system's default trust CA set.

## Motivation and Context

If app.config doesn't specify cafile, it should establish a secure
connecton and trust the certificate that signed by a well known Issuer.
However, if cafile is not specified, the selftest complains about the
insecure connection, which is inaccurate.

## How Has This Been Tested?

In app.config, keep `cafile` unchanged (or comment it out), and trigger selftest. It should warns "Only allows the connections that trusted by operating system" instead of "connection will not be secure"

## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/IBMResilient/resilient-community-apps/blob/master/CONTRIBUTING.md)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run pep8 and pylint. I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Raphanus Lo <coldturnip@gmail.com>