### PR TITLE
Add requirements file into base Dockerfile

### DIFF
--- a/resilient-sdk/resilient_sdk/data/codegen/templates/package_template/Dockerfile.jinja2
+++ b/resilient-sdk/resilient_sdk/data/codegen/templates/package_template/Dockerfile.jinja2
@@ -32,6 +32,10 @@ RUN pip install /tmp/packages/${APPLICATION}-*.tar.gz
 # uncomment and replicate if additional pypi packages are needed
 #RUN pip install <package>
 
+# uncomment and replicate if additional pypi packages in requirements file are needed
+#COPY /path/to/<requirements.txt> /tmp/packages/.
+#RUN pip install -r /tmp/packages/<requirements.txt>
+
 # uncomment and replicate if additional local packages are needed
 #COPY /path/to/extra_package /tmp/packages/.
 #RUN pip install /tmp/packages/<extra_package>*.tar.gz


### PR DESCRIPTION
## Description
Greetings! A small change in the Jinja for the Dockerfile for easier access.
Adds a way to install pypi packages found in a text file directly in the Dockerfile for easier access. I think it is a nice and usual addition that might be missed if not added.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solves some developers not realizing they can use an external requirements file in their AppHost installations.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
* Generated a new integration using resilient-sdk
* Added some placeholder code and a requirements.txt with a simple package in the base folder
* Added the changes into Dockerfile
* Built and pushed the Dockerfile
* Deployed the resultant zip into Resilient

![image](https://user-images.githubusercontent.com/47125355/218521243-b9d67260-01ba-40d2-b46e-5ac215d966d1.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/IBMResilient/resilient-community-apps/blob/master/CONTRIBUTING.md)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run pep8 and pylint. I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by:
DCO 1.1 Signed-off-by: [Pol Estecha] <[polestecha14 at g mail dot com]>